### PR TITLE
fix ip control return value for ip3511

### DIFF
--- a/device/usb_device_lpcip3511.c
+++ b/device/usb_device_lpcip3511.c
@@ -2299,11 +2299,13 @@ usb_status_t USB_DeviceLpc3511IpControl(usb_device_controller_handle controllerH
         case kUSB_DeviceControlRun:
             lpc3511IpState->registerBase->DEVCMDSTAT |= (USB_LPC3511IP_DEVCMDSTAT_DCON_MASK);
             lpc3511IpState->registerBase->DEVCMDSTAT &= ~(USB_LPC3511IP_DEVCMDSTAT_FORCE_NEEDCLK_MASK);
+            error = kStatus_USB_Success;
             break;
 
         case kUSB_DeviceControlStop:
             lpc3511IpState->registerBase->DEVCMDSTAT |= USB_LPC3511IP_DEVCMDSTAT_FORCE_NEEDCLK_MASK;
             lpc3511IpState->registerBase->DEVCMDSTAT &= (~USB_LPC3511IP_DEVCMDSTAT_DCON_MASK);
+            error = kStatus_USB_Success;
             break;
 
         case kUSB_DeviceControlEndpointInit:


### PR DESCRIPTION
without this kStatus_USB_Error was always returned for kUSB_DeviceControlRun and kUSB_DeviceControlStop control types. let's do it as for ehci/khci.